### PR TITLE
Embed Mermaid flowchart in README for GitHub rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,35 @@ stordb is a Python venv application with a SQLite backend and AES256-encrypted A
 
 ## How it works
 
+
 Visual workflow:
 
-![Vault Flowchart](docs/vault_flowchart.mmd)
+```mermaid
+flowchart TD
+    subgraph Vault
+        vault_db["sqlite (vault)"]
+    end
+    subgraph myvault
+        myvault_db["sqlite"]
+    end
+    myvault_db -->|create| myvault
+    myvault_db -->|read| myvault
+    myvault_db -->|update| myvault
+    myvault_db -->|delete| myvault
+    myvault_db -->|merge| myvault
+    myvault -->|sync| vault_db
+    vault_db -->|sync| myvault
+    myvault -->|create/read/update/delete/merge| myvault_db
 
-See `docs/vault_flowchart.mmd` for a diagram of database and vault operations.
+    %% Operations
+    myvault_db -.->|create| vault_db
+    myvault_db -.->|read| vault_db
+    myvault_db -.->|update| vault_db
+    myvault_db -.->|delete| vault_db
+    myvault_db -.->|merge| vault_db
+```
+
+See `docs/vault_flowchart.mmd` for the source diagram.
 
 ## Features
 


### PR DESCRIPTION
This PR embeds the Mermaid flowchart directly in the README, allowing GitHub to render the diagram for visual learners. The previous broken image link is replaced with a fenced mermaid code block. No functional changes to code or tests.